### PR TITLE
adds ar marker mirror

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -41,7 +41,8 @@ module.exports = {
           'depthWrite',
           'side',
           'wireframe',
-          'attach'
+          'attach',
+          'visible'
         ]
       }
     ],

--- a/src/common/components/ARMarkerMirror.tsx
+++ b/src/common/components/ARMarkerMirror.tsx
@@ -1,0 +1,34 @@
+import React, { RefObject, useMemo, useRef } from 'react';
+import { Group } from 'three';
+import { useFrame } from '@react-three/fiber';
+
+const ARMarkerMirror: React.FC<
+  React.PropsWithChildren<{ markerChildRef: RefObject<Group> }>
+> = ({ children, markerChildRef }) => {
+  const groupRef = useRef<Group>(null);
+
+  const marker = useMemo(() => {
+    const current = markerChildRef.current;
+
+    if (!current) {
+      return undefined;
+    }
+
+    return current.parent as Group;
+  }, [markerChildRef]);
+
+  useFrame(() => {
+    const mirror = groupRef.current;
+
+    if (!marker || !mirror) {
+      return;
+    }
+
+    mirror.position.copy(marker.position);
+    mirror.rotation.copy(marker.rotation);
+  });
+
+  return <group ref={groupRef}>{children}</group>;
+};
+
+export default ARMarkerMirror;

--- a/src/common/components/PersistentARMarker.tsx
+++ b/src/common/components/PersistentARMarker.tsx
@@ -1,0 +1,45 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { ARMarker } from '@artcom/react-three-arjs';
+import ARMarkerMirror from './ARMarkerMirror.tsx';
+import { Group } from 'three';
+
+/**
+ * An AR marker that keeps the marker visible at all times.
+ * @param markerUrl The url for the marker pattern.
+ * @param children The children to display within the marker.
+ */
+const PersistentARMarker: React.FC<
+  React.PropsWithChildren<{ markerUrl: string }>
+> = ({ markerUrl, children }) => {
+  const markerChildRef = useRef<Group>(null);
+  const [isMarkerVisible, setIsMarkerVisible] = useState(false);
+
+  const onMarkerFound = useCallback(() => {
+    setIsMarkerVisible(true);
+  }, []);
+
+  const onMarkerLost = useCallback(() => {
+    setIsMarkerVisible(false);
+  }, []);
+
+  return (
+    <>
+      <ARMarkerMirror
+        markerChildRef={markerChildRef}
+        isMarkerVisible={isMarkerVisible}
+      >
+        {children}
+      </ARMarkerMirror>
+      <ARMarker
+        type="pattern"
+        patternUrl={markerUrl}
+        onMarkerFound={onMarkerFound}
+        onMarkerLost={onMarkerLost}
+      >
+        <group ref={markerChildRef} />
+      </ARMarker>
+    </>
+  );
+};
+
+export default PersistentARMarker;

--- a/src/common/components/__tests__/ARMarkerMirror.test.tsx
+++ b/src/common/components/__tests__/ARMarkerMirror.test.tsx
@@ -1,0 +1,116 @@
+import ReactThreeTestRenderer from '@react-three/test-renderer';
+import ARMarkerMirror from '../ARMarkerMirror.tsx';
+import { RefObject } from 'react';
+import { Euler, Group, Quaternion, Vector3 } from 'three';
+import lerpWithMaxDelta from '../../utils/lerp-with-max-delta.ts';
+import slerpWithMaxDelta from '../../utils/slerp-with-max-delta.ts';
+
+vi.mock('../../utils/lerp-with-max-delta.ts');
+vi.mock('../../utils/slerp-with-max-delta.ts');
+
+const markerPosition = new Vector3(10, 11, 12);
+const markerRotation = new Euler(13, 14, 15);
+const markerRotationQuaternion = new Quaternion().setFromEuler(markerRotation);
+
+const markerChildRef = {
+  current: {
+    parent: {
+      position: markerPosition.clone(),
+      rotation: markerRotation.clone(),
+      quaternion: markerRotationQuaternion
+    }
+  }
+} as RefObject<Group>;
+
+const setup = (isMarkerVisible: boolean) => {
+  return ReactThreeTestRenderer.create(
+    <ARMarkerMirror
+      markerChildRef={markerChildRef}
+      isMarkerVisible={isMarkerVisible}
+    >
+      <group name="ar-marker-mirror-child" />
+    </ARMarkerMirror>
+  );
+};
+
+const getMirrorGroup = (
+  renderer: Awaited<ReturnType<typeof ReactThreeTestRenderer.create>>
+) => renderer.scene.findByProps({ name: 'ar-marker-mirror-child' }).parent;
+
+describe('<ARMarkerMirror/>', () => {
+  beforeEach(() => {
+    markerChildRef.current?.parent?.position.copy(markerPosition);
+    markerChildRef.current?.parent?.rotation.copy(markerRotation);
+    markerChildRef.current?.parent?.quaternion.setFromEuler(markerRotation);
+  });
+
+  it('should not make the mirror visible if the marker has not been visible', async () => {
+    const renderer = await setup(false);
+
+    expect(getMirrorGroup(renderer)?.instance.visible).toBeFalsy();
+  });
+
+  it('should make the mirror visible if the marker has been visible', async () => {
+    const renderer = await setup(true);
+
+    expect(getMirrorGroup(renderer)?.instance.visible).toBeTruthy();
+  });
+
+  it('should keep the mirror visible even if the marker is no longer visible', async () => {
+    const renderer = await setup(true);
+
+    expect(getMirrorGroup(renderer)?.instance.visible).toBeTruthy();
+
+    await renderer.update(
+      <ARMarkerMirror markerChildRef={markerChildRef} isMarkerVisible={false}>
+        <group name="ar-marker-mirror-child" />
+      </ARMarkerMirror>
+    );
+
+    expect(getMirrorGroup(renderer)?.instance.visible).toBeTruthy();
+  });
+
+  it('should exactly mirror the position of the marker upon first finding it', async () => {
+    const renderer = await setup(true);
+
+    const mirrorGroup = getMirrorGroup(renderer);
+    expect(mirrorGroup?.instance.position.x).toEqual(
+      markerChildRef.current?.parent?.position.x
+    );
+    expect(mirrorGroup?.instance.position.y).toEqual(
+      markerChildRef.current?.parent?.position.y
+    );
+    expect(mirrorGroup?.instance.position.z).toEqual(
+      markerChildRef.current?.parent?.position.z
+    );
+    expect(mirrorGroup?.instance.rotation.x).toEqual(
+      markerChildRef.current?.parent?.rotation.x
+    );
+    expect(mirrorGroup?.instance.rotation.y).toEqual(
+      markerChildRef.current?.parent?.rotation.y
+    );
+    expect(mirrorGroup?.instance.rotation.z).toEqual(
+      markerChildRef.current?.parent?.rotation.z
+    );
+  });
+
+  it('should lerp the position and slerp the rotation towards the marker on each frame', async () => {
+    const renderer = await setup(true);
+
+    await renderer.advanceFrames(1, 1);
+
+    const mirrorGroup = getMirrorGroup(renderer);
+    expect(lerpWithMaxDelta).toHaveBeenCalledWith(
+      mirrorGroup?.instance.position,
+      markerChildRef.current?.parent?.position,
+      0.3,
+      100
+    );
+    expect(slerpWithMaxDelta).toHaveBeenCalledWith(
+      mirrorGroup?.instance.quaternion,
+      markerChildRef.current?.parent?.quaternion,
+      0.2,
+      1
+    );
+  });
+});

--- a/src/common/utils/__tests__/lerp-with-max-delta.test.ts
+++ b/src/common/utils/__tests__/lerp-with-max-delta.test.ts
@@ -1,0 +1,31 @@
+import { Vector3 } from 'three';
+import lerpWithMaxDelta from '../lerp-with-max-delta.ts';
+
+describe('lerpWithMaxDelta', () => {
+  it('should lerp if the delta is less than the max delta', () => {
+    const from = new Vector3(0, 0, 0);
+    const to = new Vector3(0, 10, 0);
+
+    lerpWithMaxDelta(from, to, 0.1, 11);
+
+    expect(from.y).toEqual(1);
+  });
+
+  it('should lerp if the delta is equal to the max delta', () => {
+    const from = new Vector3(0, 0, 0);
+    const to = new Vector3(0, 10, 0);
+
+    lerpWithMaxDelta(from, to, 0.1, 10);
+
+    expect(from.y).toEqual(1);
+  });
+
+  it('should not lerp if the delta greater than the max delta', () => {
+    const from = new Vector3(0, 0, 0);
+    const to = new Vector3(0, 10, 0);
+
+    lerpWithMaxDelta(from, to, 0.1, 5);
+
+    expect(from.y).toEqual(0);
+  });
+});

--- a/src/common/utils/__tests__/slerp-with-max-delta.test.ts
+++ b/src/common/utils/__tests__/slerp-with-max-delta.test.ts
@@ -1,0 +1,31 @@
+import { Quaternion } from 'three';
+import slerpWithMaxDelta from '../slerp-with-max-delta.ts';
+
+describe('slerpWithMaxDelta', () => {
+  it('should slerp if the delta is less than max delta', () => {
+    const from = new Quaternion(0, 0, 0, 0);
+    const to = new Quaternion(0, 10, 0, 0);
+
+    slerpWithMaxDelta(from, to, 0.1, 11);
+
+    expect(from.y).toBeCloseTo(1.5, 0);
+  });
+
+  it('should slerp if the delta is equal to the max delta', () => {
+    const from = new Quaternion(0, 0, 0, 0);
+    const to = new Quaternion(0, 10, 0, 0);
+
+    slerpWithMaxDelta(from, to, 0.1, 10);
+
+    expect(from.y).toBeCloseTo(1.5, 0);
+  });
+
+  it('should not slerp if the delta is greater than the max delta', () => {
+    const from = new Quaternion(0, 0, 0, 0);
+    const to = new Quaternion(0, 10, 0, 0);
+
+    slerpWithMaxDelta(from, to, 0.1, 1);
+
+    expect(from.y).toEqual(0);
+  });
+});

--- a/src/common/utils/lerp-with-max-delta.ts
+++ b/src/common/utils/lerp-with-max-delta.ts
@@ -1,0 +1,25 @@
+import { Vector3 } from 'three';
+
+/**
+ * Lerps the "from" vector to the "to" vector with the given alpha. Does not lerp if the delta between the two values is larger than max delta.
+ * @param from The vector to lerp from (will be mutated)
+ * @param to The vector to lerp to
+ * @param alpha The speed at which to lerp
+ * @param maxDelta The max delta before lerp stops
+ */
+const lerpWithMaxDelta = (
+  from: Vector3,
+  to: Vector3,
+  alpha: number,
+  maxDelta: number
+) => {
+  const delta = from.distanceTo(to);
+
+  if (delta > maxDelta) {
+    return;
+  }
+
+  from.lerp(to, alpha);
+};
+
+export default lerpWithMaxDelta;

--- a/src/common/utils/slerp-with-max-delta.ts
+++ b/src/common/utils/slerp-with-max-delta.ts
@@ -1,0 +1,25 @@
+import { Quaternion } from 'three';
+
+/**
+ * Slerps the "from" quaternion to the "to" quaternion with the given alpha. Does not slerp if the delta between the two values is larger than max delta.
+ * @param from The quaternion to slerp from (will be mutated)
+ * @param to The quaternion to slerp to
+ * @param alpha The speed at which to slerp
+ * @param maxDelta The max delta before slerp stops
+ */
+const slerpWithMaxDelta = (
+  from: Quaternion,
+  to: Quaternion,
+  alpha: number,
+  maxDelta: number
+) => {
+  const delta = from.angleTo(to);
+
+  if (delta > maxDelta) {
+    return;
+  }
+
+  from.slerp(to, alpha);
+};
+
+export default slerpWithMaxDelta;

--- a/src/scene/SceneManager.tsx
+++ b/src/scene/SceneManager.tsx
@@ -1,7 +1,7 @@
 import { ARCanvas, ARMarker } from '@artcom/react-three-arjs';
 import { ViewComponent } from '../view/types/view-component.ts';
 import getSceneConfig from './get-scene-config.ts';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
 import fitGlToWindow from './utils/fit-gl-to-window.ts';
 import LoaderProvider from '../common/loader/LoaderProvider.tsx';
 import LoaderTracker from '../common/loader/LoaderTracker.tsx';
@@ -12,6 +12,8 @@ import ViewName from '../view/types/view-name.ts';
 import ARRenderSizeSynchronizer from '../common/components/ARRenderSizeSynchronizer.tsx';
 import RenderIf from '../common/components/RenderIf.tsx';
 import ModelOutliner from '../common/components/ModelOutliner.tsx';
+import { Group } from 'three';
+import ARMarkerMirror from '../common/components/ARMarkerMirror.tsx';
 
 /**
  * Manages AR scenes.
@@ -19,6 +21,7 @@ import ModelOutliner from '../common/components/ModelOutliner.tsx';
 const SceneManager: ViewComponent = ({ changeView }) => {
   const config = useMemo(getSceneConfig, []);
   const [currentScene, setCurrentScene] = useState(config.defaultScene);
+  const groupRef = useRef<Group>(null);
 
   const onRestart = useCallback(() => {
     changeView(ViewName.LANDING_PAGE);
@@ -48,11 +51,7 @@ const SceneManager: ViewComponent = ({ changeView }) => {
           <color attach="background" args={['skyblue']} />
         </RenderIf>
         <SceneLighting />
-        <ARMarker
-          type="pattern"
-          patternUrl={markerUrl}
-          params={{ smooth: true }}
-        >
+        <ARMarkerMirror markerChildRef={groupRef}>
           <ModelOutliner color={0xffffff}>
             <CurrentSceneComponent />
             <SceneControls
@@ -64,6 +63,13 @@ const SceneManager: ViewComponent = ({ changeView }) => {
               nextSceneTransition={nextSceneTransition}
             />
           </ModelOutliner>
+        </ARMarkerMirror>
+        <ARMarker
+          type="pattern"
+          patternUrl={markerUrl}
+          params={{ smooth: true }}
+        >
+          <group ref={groupRef} />
         </ARMarker>
       </ARCanvas>
     </LoaderProvider>

--- a/src/scene/SceneManager.tsx
+++ b/src/scene/SceneManager.tsx
@@ -1,7 +1,7 @@
-import { ARCanvas, ARMarker } from '@artcom/react-three-arjs';
+import { ARCanvas } from '@artcom/react-three-arjs';
 import { ViewComponent } from '../view/types/view-component.ts';
 import getSceneConfig from './get-scene-config.ts';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import fitGlToWindow from './utils/fit-gl-to-window.ts';
 import LoaderProvider from '../common/loader/LoaderProvider.tsx';
 import LoaderTracker from '../common/loader/LoaderTracker.tsx';
@@ -12,8 +12,7 @@ import ViewName from '../view/types/view-name.ts';
 import ARRenderSizeSynchronizer from '../common/components/ARRenderSizeSynchronizer.tsx';
 import RenderIf from '../common/components/RenderIf.tsx';
 import ModelOutliner from '../common/components/ModelOutliner.tsx';
-import { Group } from 'three';
-import ARMarkerMirror from '../common/components/ARMarkerMirror.tsx';
+import PersistentARMarker from '../common/components/PersistentARMarker.tsx';
 
 /**
  * Manages AR scenes.
@@ -21,7 +20,6 @@ import ARMarkerMirror from '../common/components/ARMarkerMirror.tsx';
 const SceneManager: ViewComponent = ({ changeView }) => {
   const config = useMemo(getSceneConfig, []);
   const [currentScene, setCurrentScene] = useState(config.defaultScene);
-  const groupRef = useRef<Group>(null);
 
   const onRestart = useCallback(() => {
     changeView(ViewName.LANDING_PAGE);
@@ -51,7 +49,7 @@ const SceneManager: ViewComponent = ({ changeView }) => {
           <color attach="background" args={['skyblue']} />
         </RenderIf>
         <SceneLighting />
-        <ARMarkerMirror markerChildRef={groupRef}>
+        <PersistentARMarker markerUrl={markerUrl}>
           <ModelOutliner color={0xffffff}>
             <CurrentSceneComponent />
             <SceneControls
@@ -63,14 +61,7 @@ const SceneManager: ViewComponent = ({ changeView }) => {
               nextSceneTransition={nextSceneTransition}
             />
           </ModelOutliner>
-        </ARMarkerMirror>
-        <ARMarker
-          type="pattern"
-          patternUrl={markerUrl}
-          params={{ smooth: true }}
-        >
-          <group ref={groupRef} />
-        </ARMarker>
+        </PersistentARMarker>
       </ARCanvas>
     </LoaderProvider>
   );

--- a/src/scene/__tests__/SceneManager.test.tsx
+++ b/src/scene/__tests__/SceneManager.test.tsx
@@ -9,8 +9,10 @@ import { AnimationProvider } from '../../animations/AnimationProvider.tsx';
 
 // The following mocks are required because they render things that are not compatible with ReactThreeTestRenderer
 vi.mock('@artcom/react-three-arjs', () => ({
-  ARCanvas: ({ children }: React.PropsWithChildren) => <>{children}</>,
-  ARMarker: ({ children }: React.PropsWithChildren) => <>{children}</>
+  ARCanvas: ({ children }: React.PropsWithChildren) => <>{children}</>
+}));
+vi.mock('../../common/components/PersistentARMarker.tsx', () => ({
+  default: ({ children }: React.PropsWithChildren) => <>{children}</>
 }));
 vi.mock('../../common/loader/LoaderTracker.tsx', () => ({
   default: ({ children }: React.PropsWithChildren) => <>{children}</>


### PR DESCRIPTION
This is the first step towards us having more control over the marker. Future iterations may use things like the device accelerometer to predict where the marker should be when the actual marker is not tracking. However this change simply does the following:

- Keeps the marker visible at all times after it has been found once
- Smooth tracks the marker
- Does not track the marker if the position/rotation has moved a large amount 