### PR TITLE
moves fact trigger to tooltip rather than Psyche

### DIFF
--- a/src/scene/scenes/OrbitScene.tsx
+++ b/src/scene/scenes/OrbitScene.tsx
@@ -193,16 +193,16 @@ const OrbitScene: SceneComponent = () => {
           <ARTooltip position={[3, 7, -4]} />
         </RenderIf>
       </FactsModalTrigger>
-      <FactsModalTrigger factName="psyche">
-        <Psyche
-          position={[0.25, -0.25, -5]}
-          scale={psycheScale}
-          rotation={[Math.PI / 2, 0, 0]}
-        />
-        <RenderIf shouldRender={!isTransitioning}>
+      <Psyche
+        position={[0.25, -0.25, -5]}
+        scale={psycheScale}
+        rotation={[Math.PI / 2, 0, 0]}
+      />
+      <RenderIf shouldRender={!isTransitioning}>
+        <FactsModalTrigger factName="psyche">
           <ARTooltip position={[-6, 2, 0]} />
-        </RenderIf>
-      </FactsModalTrigger>
+        </FactsModalTrigger>
+      </RenderIf>
       <group ref={orbiterGroupRef}>
         <group ref={orbiterInnerGroupRef}>
           <CruiseOrbiter


### PR DESCRIPTION
Since the `<FactsModalTrigger>` wrapped the Psyche component, any time an orbit tooltip was displayed overtop Psyche due to the camera orientation, the Psyche fact would display when clicking the orbit tooltip. Fixed by moving the facts trigger to just the Psyche tooltip.