### PR TITLE
removes torus from <FactsModalTrigger>

### DIFF
--- a/src/scene/scenes/OrbitScene.tsx
+++ b/src/scene/scenes/OrbitScene.tsx
@@ -163,21 +163,21 @@ const OrbitScene: SceneComponent = () => {
       <FactsModalTrigger factName="psycheOrbitA">
         <RenderIf shouldRender={!isTransitioning}>
           <ARTooltip position={[6, 0, 7]} />
-          {torusObjects.map((torusProps, index) => (
-            <Torus
-              key={index}
-              args={torusProps.args as [number, number, number, number, number]}
-              position={torusProps.position}
-              rotation={torusProps.rotation}
-              material={
-                currentScene === torusProps.scene && !isTransitioning
-                  ? activeTorusMaterial
-                  : torusMaterial
-              }
-            />
-          ))}
         </RenderIf>
       </FactsModalTrigger>
+      {torusObjects.map((torusProps, index) => (
+        <Torus
+          key={index}
+          args={torusProps.args as [number, number, number, number, number]}
+          position={torusProps.position}
+          rotation={torusProps.rotation}
+          material={
+            currentScene === torusProps.scene && !isTransitioning
+              ? activeTorusMaterial
+              : torusMaterial
+          }
+        />
+      ))}
       <FactsModalTrigger factName="psycheOrbitB">
         <RenderIf shouldRender={!isTransitioning}>
           <ARTooltip position={[6, 2, 5]} />


### PR DESCRIPTION
Noticed that clicking on tooltips for orbits B-D would sometimes show the modal for orbit A. This was because the <FactsModalTrigger> was wrapping the entire torus for orbit A, so depending on the camera orientation the wrong modal might display.